### PR TITLE
Issue #19 replace api url hard coded to env for dynamic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ All source code is available under our GitHub organization:
 
 ## 🧪 Local Setup Instructions
 
+> ⚠️ **Warning:** You must create a `.env` file at the root of the project and set the following environment variable:
+>
+> ```plaintext
+> NEXT_PUBLIC_API_URL=https://www.jeepedia.in
+> ```
+
 ```bash
 # Clone the repo
 git clone https://github.com/J2J-App/frontend.git

--- a/src/app/compare/layout.tsx
+++ b/src/app/compare/layout.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
     openGraph: {
     title: 'The no-bullshit tool for JEE counselling',
     description: 'JEE Pedia is your ultimate guide to cracking Counselling – get real cutoffs, accurate placement data and branch comparisons all in one place.',
-    url: 'https://jeepedia.in',
+    url: process.env.NEXT_PUBLIC_API_URL || 'https://jeepedia.in', // Issue #19: URL is now loaded from an environment variable
     siteName: 'JEEPedia',
     images: [
       {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
     openGraph: {
     title: 'The no-bullshit tool for JEE counselling',
     description: 'JEE Pedia is your ultimate guide to cracking Counselling – get real cutoffs, accurate placement data and branch comparisons all in one place.',
-    url: 'https://jeepedia.in',
+    url: process.env.NEXT_PUBLIC_API_URL || 'https://jeepedia.in', //  Issue #19: URL is now loaded from an environment variable
     siteName: 'JEEPedia',
     images: [
       {

--- a/src/app/predictor/page.tsx
+++ b/src/app/predictor/page.tsx
@@ -21,12 +21,12 @@ export const metadata: Metadata = {
     "College Comparison",
     "JEE Rank Predictor",
   ],
-  metadataBase: new URL("https://www.jeepedia.in/"),
+  metadataBase: new URL(process.env.NEXT_PUBLIC_API_URL || "https://www.jeepedia.in"), // Issue #19: URL is now loaded from an environment variable
   openGraph: {
     title: "JEE Pedia | Accurate College Predictor for JEE Mains",
     description:
       "Predict your college using your JEE rank. Real-time cutoffs, branch-wise trends, and tools for JoSAA, JAC and more.",
-    url: "https://www.jeepedia.in/predictor",
+    url: process.env.NEXT_PUBLIC_API_URL || "https://www.jeepedia.in/predictor", // Issue #19: URL is now loaded from an environment variable
     siteName: "JEEPedia",
   },
 };

--- a/src/app/predictor/page.tsx
+++ b/src/app/predictor/page.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
     title: "JEE Pedia | Accurate College Predictor for JEE Mains",
     description:
       "Predict your college using your JEE rank. Real-time cutoffs, branch-wise trends, and tools for JoSAA, JAC and more.",
-    url: process.env.NEXT_PUBLIC_API_URL || "https://www.jeepedia.in/predictor", // Issue #19: URL is now loaded from an environment variable
+    url: `${process.env.NEXT_PUBLIC_API_URL || "https://www.jeepedia.in"}/predictor`, // Issue #19: URL is now loaded from an environment variable
     siteName: "JEEPedia",
   },
 };

--- a/src/app/robot.ts
+++ b/src/app/robot.ts
@@ -1,6 +1,7 @@
 import { Metadata, MetadataRoute } from "next";
 
 export default function robot() : MetadataRoute.Robots {
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL || "https://www.jeepedia.in"; // Fallback URL if environment variable is not found
     return {
         rules: [
             {
@@ -9,6 +10,6 @@ export default function robot() : MetadataRoute.Robots {
                 disallow: "/api/",
             },
         ],
-        sitemap: "https://www.jeepedia.in/sitemap.xml",
+        sitemap: `${apiUrl}/sitemap.xml` // Issue #19: URL is now loaded from an environment variable
     };
 }

--- a/src/app/universities/[counselling]/[uni]/layout.tsx
+++ b/src/app/universities/[counselling]/[uni]/layout.tsx
@@ -8,6 +8,8 @@ export const generateMetadata = ({
 }): Metadata => {
   const { counselling, uni } = params;
 
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "https://www.jeepedia.in"; // Fallback URL if environment variable is not found
+
   return {
     title: `${uni.toUpperCase()} Cutoff 2024 | Jeepedia`,
     description: `Explore ${uni.toUpperCase()}'s 2024 cutoff trends and counselling updates for ${counselling.toUpperCase()}.`,
@@ -34,7 +36,7 @@ export const generateMetadata = ({
     openGraph: {
       title: `${uni.toUpperCase()} Cutoff 2024 | Jeepedia`,
       description: `Explore ${uni.toUpperCase()}'s 2024 cutoff trends and counselling updates for ${counselling.toUpperCase()}.`,
-      url: `https://www.jeepedia.in/universities/${counselling}/${uni}/cutoff`,
+      url: `${apiUrl}/universities/${counselling}/${uni}/cutoff`, // Issue #19: URL is now loaded from an environment variable
       siteName: "Jeepedia",
     },
     icons: {


### PR DESCRIPTION
Fixes #19 

- Added support for loading the API URL from a .env file using the NEXT_PUBLIC_API_URL environment variable.
- Implemented a fallback mechanism to handle cases where the environment variable is missing or misconfigured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a warning in the setup instructions to ensure users create a `.env` file and set the `NEXT_PUBLIC_API_URL` environment variable.

* **New Features**
  * Made various URLs in metadata and sitemap configurations dynamic based on the `NEXT_PUBLIC_API_URL` environment variable, with fallback to the default URL if not set. This affects Open Graph metadata and sitemap generation across multiple pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->