### PR TITLE
Add GSSoC Label and Level for Auto labels assignment 

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,94 @@
+name: "Auto Create & Assign Labels"
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Create colorful labels if missing and assign
+        run: |
+          #!/bin/bash
+          set -e
+
+          # Determine if it's an issue or PR
+          if [ "${{ github.event_name }}" == "issues" ]; then
+            ISSUE_NUMBER=${{ github.event.issue.number }}
+            TITLE="${{ github.event.issue.title }}"
+            BODY="${{ github.event.issue.body }}"
+            CREATOR="${{ github.event.issue.user.login }}"
+          else
+            ISSUE_NUMBER=${{ github.event.pull_request.number }}
+            TITLE="${{ github.event.pull_request.title }}"
+            BODY="${{ github.event.pull_request.body }}"
+            CREATOR="${{ github.event.pull_request.user.login }}"
+          fi
+
+          echo "Number: $ISSUE_NUMBER"
+          echo "Title: $TITLE"
+          echo "Creator: $CREATOR"
+
+          # Define colorful labels and colors (without # in JSON)
+          declare -A labels
+          labels["Level 1 / Beginner"]="7AE7FF"      # Sky Blue
+          labels["Level 2 / Intermediate"]="FFAB70"  # Orange
+          labels["Level 3 / Advanced"]="FF7F7F"      # Red
+          labels["GSSoC 25"]="6F42C1"                # Purple
+
+          # Create labels if missing
+          for label in "${!labels[@]}"; do
+            response=$(curl -s -o /dev/null -w "%{http_code}" \
+              -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/${GITHUB_REPOSITORY}/labels \
+              -d "{\"name\":\"$label\",\"color\":\"${labels[$label]}\"}")
+            if [[ "$response" == "422" ]]; then
+              echo "Label '$label' already exists."
+            else
+              echo "Label '$label' created with color ${labels[$label]}."
+            fi
+          done
+
+          sleep 2  # Ensure labels are registered
+
+          # Determine complexity level
+          LEVEL_LABEL="Level 3 / Advanced"
+          if echo "$TITLE$BODY" | grep -iqE "typo|doc|readme|ui"; then
+            LEVEL_LABEL="Level 1 / Beginner"
+          elif echo "$TITLE$BODY" | grep -iqE "feature|bug|small"; then
+            LEVEL_LABEL="Level 2 / Intermediate"
+          fi
+
+          echo "Level label: $LEVEL_LABEL"
+
+          # Assign labels and creator
+          ASSIGN_RESPONSE=$(curl -s -w "%{http_code}" -o /dev/null \
+            -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/$ISSUE_NUMBER/labels \
+            -d "{\"labels\":[\"GSSoC 25\",\"$LEVEL_LABEL\"]}")
+
+          ASSIGNEE_RESPONSE=$(curl -s -w "%{http_code}" -o /dev/null \
+            -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/$ISSUE_NUMBER/assignees \
+            -d "{\"assignees\":[\"$CREATOR\"]}")
+
+          echo "Labels and assignee successfully assigned: GSSoC 25, $LEVEL_LABEL"


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #76 

## Rationale for this change

This PR adds an **automatic label assignment workflow** for all newly created issues and pull requests.  
It ensures:

- Labels `Level 1 / Beginner`, `Level 2 / Intermediate`, `Level 3 / Advanced` and `GSSoC 25` are automatically created (if not already present) with proper colors.  
- Labels are assigned based on **title and body keywords** to indicate complexity/impact.  
- Works for both **issues and PRs**, simplifying contribution management.

This improves consistency, saves manual labeling effort, and helps track GSSoC contributions automatically.

## What changes are included in this PR?

- Added a new GitHub Actions workflow file:  
  `.github/workflows/auto-label.yml`  
- Logic to:
  - Create missing labels with predefined colors
  - Assign labels automatically to new issues and PRs
  - Determine complexity level (1/2/3) from title/body keywords
  - Always assign `GSSoC 25` label

## Are these changes tested?

- Workflow tested by creating **dummy issues and PRs** in a separate branch to ensure labels are automatically applied.  
- Verified that existing labels are not duplicated and colors match the defined scheme.

## Are there any user-facing changes?

- No direct user-facing changes.  
- Contributors will see labels applied automatically when they open an issue or PR.
